### PR TITLE
Revert deploy.sh script to agree with required plugin version in Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,10 @@ sudo apt install -y twilio
 Close your terminal window or tab, and open a new one. Now run:
 
 ```bash
-twilio plugins:install @twilio/plugin-microvisor
+twilio plugins:install "@twilio/plugin-microvisor@0.3.7"
 ```
+
+Note: This project currently requires the plugin-microvisor version 0.3.7.  It will not work with newer versions of the plugin.
 
 ### Environment Variables
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -270,7 +270,7 @@ if [[ ${do_deploy} -eq 1 ]]; then
     # Try to upload the bundle
     echo "Uploading ${zip_path}..."
     upload_action=$(twilio microvisor:apps:create "${zip_path}" -o=json)
-    app_sid=$(echo "${upload_action}" | jq -r '.[0].sid')
+    app_sid=$(echo "${upload_action}" | jq -r '.sid')
 
     if [[ -z "${app_sid}" || "${app_sid}" == "null" ]]; then
         show_error_and_exit "Could not upload app"


### PR DESCRIPTION
Presently, the version of the deploy.sh script used in this project requires a specific plugin version.  Document this in the README.md for folks not using the Dockerfile.  The Dockerfile already enforces this requirement.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
